### PR TITLE
Release : 2.2.7 List page - summary input bug fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ This project allows you to:
 
 ## Version History
 
+### Version 2.2.7 (2024-03-06)
+
+- Fix List page summary input bugs.
+
 ### Version 2.2.6 (2024-01-23)
 
 - Use sample data as initial data.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <meta name="author" content="Maria Kim" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ror",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/views/List/StockItem/SummaryInfo/SummaryContent.tsx
+++ b/src/views/List/StockItem/SummaryInfo/SummaryContent.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
@@ -22,12 +22,12 @@ const SummaryContent = ({ stockId, isLock, onInputChange, changedInputs }: Props
   const stockInfo = useSelector(selectStockInfoById(stockId));
   const summaryData = useGetStockSummaryData(stockId);
 
-  const stockName = changedInputs.stockName || stockInfo.mainInfo.stockName;
+  const stockName = changedInputs.stockName ?? stockInfo.mainInfo.stockName;
   const formattedCurrentPrice = changedInputs.currentPrice?.toString() || stockInfo.mainInfo.currentPrice.toString();
 
   useEffect(() => {
     if (!focusedInput.current?.disabled) focusedInput.current?.focus();
-  }, [focusedInput.current?.disabled]);
+  }, [isLock]);
 
   return (
     <>


### PR DESCRIPTION
- Add meta referrer to protect information.
- Fix stock name not clearing when editing.
- Fix focus problem. 
    - Being refocused to 'stock name'. When unlock SummaryContent. And 'current price' input is focused and changed for the first time.