### PR TITLE
Release : 2.2.8 List page - Purchased Input focus bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ This project allows you to:
 
 ## Version History
 
+### Version 2.2.8 (2024-03-06)
+
+- Fix List page purchase input bug.
+
 ### Version 2.2.7 (2024-03-06)
 
 - Fix List page summary input bugs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ror",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/views/List/StockItem/PurchasedStock/PurchasedInput.tsx
+++ b/src/views/List/StockItem/PurchasedStock/PurchasedInput.tsx
@@ -31,7 +31,7 @@ const PurchasedInput = ({ isLock, purchasedItem, changedInputs, setChangedInputB
 
   useEffect(() => {
     if (!focusedInput.current?.disabled) focusedInput.current?.focus();
-  }, [focusedInput.current?.disabled]);
+  }, [isLock]);
 
   return (
     <>

--- a/src/views/List/StockItem/SummaryInfo/SummaryContent.tsx
+++ b/src/views/List/StockItem/SummaryInfo/SummaryContent.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useLayoutEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 


### PR DESCRIPTION
- Fix focus problem.
  - Being refocused to 'purchasedDate'. 
    - When unlock Purchased. And changing other input rather than 'purchasedDate'.