### PR TITLE
fix : Note/AddNote - don't show warning when the change result is same as before

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ror",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/views/Note/NoteInfo/const.ts
+++ b/src/views/Note/NoteInfo/const.ts
@@ -1,8 +1,8 @@
 import { NoteFormState } from './type';
 
 export const INITIAL_NOTE_FORM_STATE: NoteFormState = {
-  title: null,
-  text: null,
+  title: '',
+  text: '',
   purchasedId: null,
   soldId: null,
   tag: null,

--- a/src/views/Note/NoteInfo/helper.ts
+++ b/src/views/Note/NoteInfo/helper.ts
@@ -1,16 +1,41 @@
 import { NoteFormState } from './type';
 
-export const checkAddNoteFormHasChanges = (form: NoteFormState) =>
-  Object.values(form).some(Boolean);
+const isEqual = (a: any, b: any) => {
+  if (a === b) return true;
+
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (!isEqual(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    if (
+      a.toString() === '[object Object]' &&
+      b.toString() === '[object Object]'
+    ) {
+      const aKeys = Object.keys(a);
+      const bKeys = Object.keys(b);
+      if (aKeys.length !== bKeys.length) return false;
+      for (const key of aKeys) {
+        if (!isEqual(a[key], b[key])) return false;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  return false;
+};
 
 export const checkEditNoteFormHasChanges = (
   originalForm: NoteFormState,
   currentForm: NoteFormState,
 ) => {
-  const original = Object.values(originalForm);
-  const current = Object.values(currentForm);
-
-  return original.some(
-    (originalValue, index) => originalValue !== current[index],
-  );
+  for (const key of Object.keys(originalForm) as Array<keyof NoteFormState>) {
+    if (!isEqual(originalForm[key], currentForm[key])) return true;
+  }
 };

--- a/src/views/Note/NoteInfo/modals/AddNote.tsx
+++ b/src/views/Note/NoteInfo/modals/AddNote.tsx
@@ -9,7 +9,7 @@ import NotePopupForm from '../NotePopupForm';
 import { StyledForm, StyledNoteModal } from '../components';
 import { NoteFormKeys, NoteFormState } from '../type';
 import CloseWarningModal from '../CloseWarningModal';
-import { checkAddNoteFormHasChanges } from '../helper';
+import { checkEditNoteFormHasChanges } from '../helper';
 
 interface NotePopupProps {
   onCloseModal: () => void;
@@ -41,7 +41,7 @@ function AddNote({ onCloseModal, initialFormState }: NotePopupProps) {
   };
 
   const onCheckChangeAndCloseModal = () => {
-    const changes = checkAddNoteFormHasChanges(formState);
+    const changes = checkEditNoteFormHasChanges(initialFormState, formState);
     if (changes) {
       setShowWarning(true);
       return;


### PR DESCRIPTION
fix: improve logic for checking form changes with enhanced accuracy for object comparisons(to check stock info). Now handles object values regardless of key order.
